### PR TITLE
Add Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report (suspected) security vulnerabilities to
+**[security@puzzle.ch](mailto:security@puzzle.ch)**.


### PR DESCRIPTION
Add a Security Policy as described in: https://github.blog/changelog/2019-05-23-security-policy/

> Repositories may now specify a security policy by creating a file named SECURITY.MD. This file should be used to instruct users about how and when to report security vulnerabilities to the repository maintainers. When included, this file will be shown in the repository’s “Security” tab, and in the new issue workflow.