### PR TITLE
Bug 54031 link search result

### DIFF
--- a/app/assets/javascripts/templates/api_users.hbs.erb
+++ b/app/assets/javascripts/templates/api_users.hbs.erb
@@ -16,6 +16,7 @@
       <tbody id="api_users_table_body">
         {{> _api_user_row}}
       </tbody>
+    </table>
   {{else}}
     <p> {{I18n 'profile.api_users.no_api_users' }} </p>
   {{/if}}

--- a/app/assets/javascripts/templates/search/account_full.hbs.erb
+++ b/app/assets/javascripts/templates/search/account_full.hbs.erb
@@ -10,9 +10,9 @@ https://github.com/puzzle/cryptopus. }}
     </h1>
     <br>
     <span>
-      <a href="/teams/{{team_id}}">{{team}}</a>
+      <a href="/teams/{{team_id}}">{{team_name}}</a>
       /
-      <a href="/teams/{{team_id}}/groups/{{group_id}}">{{group}}</a>
+      <a href="/teams/{{team_id}}/groups/{{group_id}}">{{group_name}}</a>
     </span>
   </div>
   <br>

--- a/app/assets/javascripts/templates/search/account_full.hbs.erb
+++ b/app/assets/javascripts/templates/search/account_full.hbs.erb
@@ -7,7 +7,7 @@ https://github.com/puzzle/cryptopus. }}
   <div class="result-description">
     <h1 class="result-title">
       <a href="accounts/{{id}}">{{accountname}}</a><br>
-    </h1
+    </h1>
     <br>
     <span>
       <a href="/teams/{{team_id}}">{{team}}</a>

--- a/app/assets/javascripts/templates/search/accounts_result_entries.hbs.erb
+++ b/app/assets/javascripts/templates/search/accounts_result_entries.hbs.erb
@@ -10,7 +10,7 @@ https://github.com/puzzle/cryptopus. }}
       <div class="result-description">
         <%= image_tag("key.svg", class:"result-type-icon", alt:"Account" ) %>
         <h4 class="result-title-small account-link">{{accountname}}</h4>
-        <div class="team-group">{{team}} / {{group}}</div>
+        <div class="team-group">{{team_name}} / {{group_name}}</div>
       </div>
     </li>
   </div>

--- a/app/assets/javascripts/templates/search/accounts_result_entries.hbs.erb
+++ b/app/assets/javascripts/templates/search/accounts_result_entries.hbs.erb
@@ -4,7 +4,7 @@ See the COPYING file at the top-level directory or at
 https://github.com/puzzle/cryptopus. }}
 
 {{#each .}}
-  <div class"result-entry">
+  <div class="result-entry">
     <li class="result-small account-entry"
       data-account-path="/api/accounts/{{id}}">
       <div class="result-description">

--- a/app/serializers/account_serializer.rb
+++ b/app/serializers/account_serializer.rb
@@ -21,8 +21,10 @@
 #  https://github.com/puzzle/cryptopus.
 
 class AccountSerializer < ApplicationSerializer
-  attributes :id, :accountname, :group,
+  attributes :id, :accountname, :group, :group_name, :group_id, :team_name, :team_id,
              :cleartext_password, :cleartext_username
+  # Note: Ember uses this serializer and expects group to return the id.
+  # Thus, next to group_id, group returns the id aswell.
 
   def cleartext_password
     object.cleartext_password
@@ -35,4 +37,21 @@ class AccountSerializer < ApplicationSerializer
   def group
     object.group.id
   end
+
+  def group_id
+    object.group.id
+  end
+
+  def group_name
+    object.group.name
+  end
+
+  def team_id
+    object.group.team.id
+  end
+
+  def team_name
+    object.group.team.name
+  end
+
 end

--- a/spec/controllers/admin/recryptrequests_controller_spec.rb
+++ b/spec/controllers/admin/recryptrequests_controller_spec.rb
@@ -111,8 +111,6 @@ describe Admin::RecryptrequestsController do
       rec.user_id = bob.id
       rec.save
 
-      recs = Recryptrequest.all
-
       get :index
 
       expect(response.body).to match(/<h1>Re-encryption requests/)


### PR DESCRIPTION
When integrating ember, attritbutes in the account_serializer had to be renamed and some were deleted. Yet, they are required for the search results. So this has been reversed, but kept compatible with ember.