### PR TITLE
Add sentry to frontend, add env-settings endpoint

### DIFF
--- a/app/controllers/api/env_settings_controller.rb
+++ b/app/controllers/api/env_settings_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Api::EnvSettingsController < ApiController
+
+  skip_before_action :validate_user
+  before_action :skip_authorization
+
+  def index
+    render_json sentry: ENV['SENTRY_DSN_FRONTEND']
+  end
+end

--- a/config/docker/mysql/mysql-prod.env.tmpl
+++ b/config/docker/mysql/mysql-prod.env.tmpl
@@ -2,5 +2,6 @@ RAILS_DB_USERNAME=root
 RAILS_DB_PASSWORD=change-me
 SECRET_KEY_BASE=change-me
 #GEO_IP_LICENSE_KEY=change-me
+#SENTRY_DSN_FRONTEND=change-me
 # same value as RAILS_DB_PASSWORD
 MYSQL_ROOT_PASSWORD=change-me-too

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
       resources :folders, only: [:show, :index, :update, :create]
     end
 
+    get 'env_settings', to: 'env_settings#index'
+
     resources :accounts, only: [:show, :index, :update, :create]
 
     resources :api_users do
@@ -35,11 +37,11 @@ Rails.application.routes.draw do
 
     # INFO don't mix scopes and resources in routes
     resources :teams, only: [:show, :index, :update, :create, :destroy]  do
-      
+
       collection do
         resources :last_member_teams, only: [:index], module: 'teams'
       end
-      
+
       resources :api_users, only: [:create, :destroy, :index], module: 'teams'
       resources :folders, only: ['index'], module: 'teams'
       resources :members, except: [:new, :edit], module: 'teams'

--- a/frontend/app/initializers/env-settings.js
+++ b/frontend/app/initializers/env-settings.js
@@ -1,0 +1,19 @@
+import ENV from "../config/environment";
+
+export function initialize(/* application */) {
+  if (ENV.environment !== "test") {
+    /* eslint-disable no-undef  */
+    $.getJSON({
+      url: "/api/env_settings",
+      async: false,
+      success: function (envSettings) {
+        ENV.sentryDsn = envSettings.sentry;
+      }
+    });
+    /* eslint-enable no-undef  */
+  }
+}
+
+export default {
+  initialize
+};

--- a/frontend/app/initializers/sentry.js
+++ b/frontend/app/initializers/sentry.js
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/browser'
+import * as Integrations from '@sentry/integrations';
+import ENV from "../config/environment";
+import { isPresent } from '@ember/utils';
+
+export function initialize() {
+  if (ENV.environment === "production" && isPresent(ENV.sentryDsn)) {
+    Sentry.init({
+      dsn: ENV.sentryDsn,
+      integrations: [new Integrations.Ember()]
+    });
+  }
+}
+
+export default {
+  after: ['env-settings'],
+  initialize
+};

--- a/frontend/config/environment.js
+++ b/frontend/config/environment.js
@@ -6,6 +6,7 @@ module.exports = function(environment) {
     environment,
     rootURL: "/app",
     locationType: "hash",
+    sentryDsn: "",
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,8 +47,8 @@
     "ember-load-initializers": "^2.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-power-select": "^3.0.4",
-    "ember-progress-bar": "^1.0.0",
     "ember-power-select-typeahead": "^0.8.0",
+    "ember-progress-bar": "^1.0.0",
     "ember-qunit": "^4.5.1",
     "ember-resolver": "^5.3.0",
     "ember-source": "~3.15.0",
@@ -65,6 +65,8 @@
     "node": "8.* || >= 10.*"
   },
   "dependencies": {
+    "@sentry/browser": "^5.16.1",
+    "@sentry/integrations": "^5.16.1",
     "clean-css": "^4.2.3",
     "ember-cli-shims": "^1.2.0",
     "minimist": "^1.2.5"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1240,6 +1240,67 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@sentry/browser@^5.16.1":
+  version "5.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.16.1.tgz#7a5ad85d9002de1495b1f63c3a4edb688a27f644"
+  integrity sha512-uXXKRGLWDqwaKO09K1GTTV0Yj+OfELVs+0cDDYqPDow+DlIXyx0gSnZPd0caCqFllUy8JSxb4S9OprYinvks2A==
+  dependencies:
+    "@sentry/core" "5.16.1"
+    "@sentry/types" "5.16.1"
+    "@sentry/utils" "5.16.1"
+    tslib "^1.9.3"
+
+"@sentry/core@5.16.1":
+  version "5.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.16.1.tgz#c5c2f5d3391440f62b3e4dbefafc776449c45c35"
+  integrity sha512-CDKUAUWefZ+bx7tUGm7pgkuJbwn+onAlwzKkLGVg730IP+N/AWSpVtbvFTPiel2+NPiFhWX5/F0SpxDMLPRKfg==
+  dependencies:
+    "@sentry/hub" "5.16.1"
+    "@sentry/minimal" "5.16.1"
+    "@sentry/types" "5.16.1"
+    "@sentry/utils" "5.16.1"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.16.1":
+  version "5.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.16.1.tgz#e35d507a134a6ab4c572304dc1143b6bccfa9b45"
+  integrity sha512-Og4zxp0lM9yS6TyKbZ5lQR94f/fNOalodm71Dk4qfBWi0OzfFCVpO4fPOhHtbXEsvMNg5xh0Pe8ezqX3CZ3hTw==
+  dependencies:
+    "@sentry/types" "5.16.1"
+    "@sentry/utils" "5.16.1"
+    tslib "^1.9.3"
+
+"@sentry/integrations@^5.16.1":
+  version "5.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-5.16.1.tgz#fc66cd0ad2df9024e16c1bca7dcb64e4819b27b2"
+  integrity sha512-RwxLZN3qSH8v8HrU5aUGh37XxiAMzIQ8rAwd6XlPelixpsvbIAUeIxhutKeBz1xn5ylhMg62GkA9IJBu3mKRZg==
+  dependencies:
+    "@sentry/types" "5.16.1"
+    "@sentry/utils" "5.16.1"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.16.1":
+  version "5.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.16.1.tgz#71d16c20a0a396ab3da07b19cb444b4459fd2b11"
+  integrity sha512-RCwEKLneV5BQlv1MEmsCR3I5jajHgVGusBgwGgnFv+4Cn4cNC7OHWH4QbuZ3IHOEHJl7YS074BeluM+7jn0+Tw==
+  dependencies:
+    "@sentry/hub" "5.16.1"
+    "@sentry/types" "5.16.1"
+    tslib "^1.9.3"
+
+"@sentry/types@5.16.1":
+  version "5.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.16.1.tgz#ba69dbf096d121b4197fdd54c35ac941b53d0b6a"
+  integrity sha512-uERNhBdsiWvWG7qTC9QVsvFmOSL8rFfy8usEXeH3l4oCQao9TvGUvXJv6gRfiWmoiJZ1A0608Lj15CORygdbng==
+
+"@sentry/utils@5.16.1":
+  version "5.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.16.1.tgz#c663858ab04bbb0cba6660fb37a4ccdb30cc2ec8"
+  integrity sha512-hn2jTc6ZH1lXGij7yqkV6cGhEYxsdjqB5P4MjfrRHB5bk5opY9R89bsAhs1rpanTdwv6Ul0ieR1z18gdIgUf0g==
+  dependencies:
+    "@sentry/types" "5.16.1"
+    tslib "^1.9.3"
+
 "@simple-dom/interface@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
@@ -10701,6 +10762,11 @@ tslib@^1.10.0, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+
+tslib@^1.9.3:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
 tty-browserify@0.0.0:
   version "0.0.0"

--- a/spec/controllers/api/env_settings_controller_spec.rb
+++ b/spec/controllers/api/env_settings_controller_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::EnvSettingsController do
+  include ControllerHelpers
+
+  before do
+    ENV['SENTRY_DSN_FRONTEND'] = '123456'
+  end
+
+  context 'GET index' do
+
+    it 'returns env_settings' do
+      get :index
+
+      expect(json['sentry']).to eq('123456')
+    end
+  end
+end


### PR DESCRIPTION
Sentry is implemented in Ember. The DSN gets retrieved via env_settings endpoint. Right now the Sentry-DSN is the only Parameter on this endpoint. Are there any other Environment Variables which could be included?