### PR TITLE
Switch to correct IP documentation ranges

### DIFF
--- a/app/views/admin/settings/_ip_whitelist.html.haml
+++ b/app/views/admin/settings/_ip_whitelist.html.haml
@@ -10,5 +10,6 @@
       placeholder:  GeoIp.activated? ? '' : t('admin.settings.index.whitelist_placeholder_geo_ip_deactivated')
 
   .hint
-    %p To specify a single ip address, just enter it like: <kbd>12.10.255.146</kbd>. IPv6 is also allowed.
-    %p To specify a range you can enter the ip address with the subnet mask: <kbd>12.0.0.0/8</kbd>. This would be the range between 12.0.0.0 and 12.255.255.255
+    %p To specify a single IP address, just enter it like: <kbd>192.0.2.10</kbd>.
+    %p To specify a range you can enter the IP address with the subnet mask: <kbd>192.0.2.0/24</kbd>. This would be the range between <kbd>192.0.2.0</kbd> and <kbd>192.0.2.255</kbd>
+    %p IPv6 is allowed and can be entered like this: <kbd>2001:db8::/32</kbd>


### PR DESCRIPTION
Switched the example IPv4 address from a privately owned block to the official documentation range.
Added an example of an IPv6 whitelist.