### PR TITLE
Small issues in translations, locale and pw meter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,8 +28,6 @@ class ApplicationController < ActionController::Base
     locale = I18n.default_locale
     if current_user
       locale = current_user.preferred_locale
-    elsif params[:locale]
-      locale = params[:locale]
     end
     I18n.locale = locale
   end

--- a/app/views/admin/maintenance_tasks/index.html.haml
+++ b/app/views/admin/maintenance_tasks/index.html.haml
@@ -26,10 +26,10 @@
 %h1= 'Logs'
 %table.table.table-striped
   %tr
-    %th= t :executed_at
-    %th= t :status
-    %th= t :output
-    %th= t :executer
+    %th= t '.executed_at'
+    %th= t '.status'
+    %th= t '.output'
+    %th= t '.executor'
   - @maintenance_logs.each do |ml|
     %tr{class: "#{cycle('odd', 'even')}"}
       %td= ml.created_at.to_time

--- a/app/views/admin/teams/index.html.haml
+++ b/app/views/admin/teams/index.html.haml
@@ -9,8 +9,8 @@
 %table.table.table-striped#teamlist_table
   %tr
     %th.teamlist-row= t '.teamname'
-    %th.teamlist-row= t '.folders'
-    %th.teamlist-row= t '.accounts'
+    %th.teamlist-row= t '.num_folders'
+    %th.teamlist-row= t '.num_accounts'
     %th.teamlist-row= t '.members'
   - @teams.each do |team|
     - @team = team

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -26,7 +26,7 @@
                   %li= nav_link t(:recrypt_requests), admin_recryptrequests_path
                 %li= nav_link t(:users), admin_users_path
                 %li= nav_link t('teams.title'), admin_teams_path
-                %li= nav_link t(:maintenance_tasks), admin_maintenance_tasks_path
+                %li= nav_link t('admin.maintenance_tasks.index.title'), admin_maintenance_tasks_path
           = nav_link image_pack_tag("sign_out.svg", class: "logout-icon"), session_destroy_path, :get
 
         %ul.nav.navbar-nav.navbar-right#profile-button

--- a/app/views/profile/index.html.haml
+++ b/app/views/profile/index.html.haml
@@ -13,7 +13,7 @@
     %a{"data-toggle" => "tab", href: "#api_users"}
       = t 'profile.api_users.api_users'
 
-.tab-content.teams-content.mb-2
+.tab-content.teams-content
   #info.tab-pane.fade.in.active
     = render 'info'
   #api_users.tab-pane.fade

--- a/app/views/profile/index.html.haml
+++ b/app/views/profile/index.html.haml
@@ -13,7 +13,7 @@
     %a{"data-toggle" => "tab", href: "#api_users"}
       = t 'profile.api_users.api_users'
 
-.tab-content.teams-content
+.tab-content.teams-content.mb-2
   #info.tab-pane.fade.in.active
     = render 'info'
   #api_users.tab-pane.fade

--- a/app/webpacker/src/stylesheets/profile.scss
+++ b/app/webpacker/src/stylesheets/profile.scss
@@ -5,6 +5,7 @@
 
 #profile-tabs {
   padding-top: 3em;
+  margin-bottom: 1em;
 }
 
 .api-user-description {

--- a/config/locales/ch_be.yml
+++ b/config/locales/ch_be.yml
@@ -38,6 +38,7 @@ ch_be:
   team: Team
   move: Bewegä
   here: hiä
+  new: Nöi
   save: Spichere
   close: Schliesse
   user: Benutzer
@@ -81,7 +82,7 @@ ch_be:
     title: Suechä
     index:
       hi_user: "Hallo %{username}! Suechsch es Passwort?"
-      no_results_found: keni Ergäbniss gfunde
+      no_results_found: äuä nüt gfunde
       type_to_search: Tippe für z sueche...
 
   accounts:
@@ -119,9 +120,15 @@ ch_be:
     maintenance_tasks:
       index:
         title: Wartigsufgabe
-        unavailable: Keni Wartigsufgabe verfüegbar
+        unavailable: Äuä ke Wartigsufgabe verfüegbar
         maintenance_task: Wartigsufgab
         run: Usfüehre
+        prepare: Vorbereite
+        execute: Usführe
+        executed_at: Usgführt am
+        status: Status
+        output: Output
+        executor: Usführer
     settings:
       index:
         title: Istellige bearbeite
@@ -171,6 +178,13 @@ ch_be:
         destroy: Benutzer lösche
       new:
         title: Nöie Benutzer
+    teams:
+      index:
+        title: Teams
+        teamname: Teamname
+        num_folders: Ahzahl Ordner
+        num_accounts: Ahzahl Accounts
+        members: Mitglieder
 
   folders:
     title: Ordner

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -93,6 +93,12 @@ de:
         unavailable: Keine Wartungsaufgaben vorhanden
         maintenance_task: Wartungsaufgabe
         run: Ausführen
+        prepare: Vorbereiten
+        execute: Ausführen
+        executed_at: Ausgeführt am
+        status: Status
+        output: Output
+        executor: Ausführer
     settings:
       index:
         title: Einstellungen bearbeiten
@@ -147,6 +153,11 @@ de:
     teams:
       index:
         title: Teams
+        teamname: Teamname
+        num_folders: Anzahl Ordner
+        num_accounts: Anzahl Accounts
+        members: Mitglieder
+
     user_roles:
       user: Benutzer
       conf_admin: Conf Admin

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,10 @@ en:
         run: execute
         prepare: prepare
         execute: execute
+        executed_at: Executed At
+        status: Status
+        output: Output
+        executor: Executor
     settings:
       index:
         title: Edit Settings
@@ -148,6 +152,10 @@ en:
     teams:
       index:
         title: Teams
+        teamname: Teamname
+        num_folders: Number of Folders
+        num_accounts: Number of Accounts
+        members: Members
     user_roles:
       user: User
       conf_admin: Conf Admin

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -67,6 +67,12 @@ fr:
       random_password: Mot de passe aléatoire
       team_placeholder: Choisissez une équipe
       folder_placeholder: Choisissez un dossier
+      password_strength: Fiabilité du mot de passe
+      password_strengths:
+        weak: Faible
+        fair: Approprié
+        good: Bien
+        strong: Fort
     show:
       title: "Compte: %{account_name}"
       last_change: "Dernière mise à jour il ya %{time_ago}"
@@ -85,6 +91,12 @@ fr:
         unavailable: Il n'y a pas de tâches de maintenance
         maintenance_task: Tâche de maintenance
         run: effectuer
+        prepare: préparer
+        execute: effectuer
+        executed_at: Effectué à
+        status: Statut
+        output: Output
+        executor: Effectueur
     settings:
       index:
         title: Modifier les paramètres
@@ -138,6 +150,10 @@ fr:
     teams:
       index:
         title: Teams
+        teamname: Nom de l'équipe
+        num_folders: Nombre de dossiers
+        num_accounts: Nombre de comptes
+        members: Membres
     user_roles:
       user: Utilisateur
       conf_admin: Conf Admin
@@ -363,6 +379,7 @@ fr:
         surname: Nom de famille
       account:
         account: Compte
+        account_name: Nom du compte
         username: Nom d'utilisateur
         password: Mot de passe
         description: Description

--- a/frontend/app/components/password-strength-meter.js
+++ b/frontend/app/components/password-strength-meter.js
@@ -16,19 +16,12 @@ export default class PasswordStrengthMeterComponent extends Component {
   }
 
   didReceiveAttrs() {
-    if (isPresent(this.password)) {
+    if (isPresent(this.password) && this.password !== "") {
       this.passwordStrength.strength(this.password).then(strength => {
         this.score = strength.score;
-
-        if(this.password === "")
-          this.barWidth = 0;
-        else  {
-          if (this.score === 0)
-            this.score = 1;
-          this.barWidth = this.score * 25;
-        }
-
-
+        if (this.score === 0)
+          this.score = 1;
+        this.barWidth = this.score * 25;
       });
     } else {
       this.score = 0;

--- a/frontend/app/components/password-strength-meter.js
+++ b/frontend/app/components/password-strength-meter.js
@@ -20,7 +20,15 @@ export default class PasswordStrengthMeterComponent extends Component {
       this.passwordStrength.strength(this.password).then(strength => {
         this.score = strength.score;
 
-        this.barWidth = this.score === 0 ? 10 : this.score * 25;
+        if(this.password === "")
+          this.barWidth = 0;
+        else  {
+          if (this.score === 0)
+            this.score = 1;
+          this.barWidth = this.score * 25;
+        }
+
+
       });
     } else {
       this.score = 0;

--- a/frontend/app/templates/components/account-form.hbs
+++ b/frontend/app/templates/components/account-form.hbs
@@ -50,7 +50,7 @@
               <div class="d-flex col-sm-12">
                 <div class="form-group col-sm-6">
                   <div class="row">
-                    <Input class="form-control secret mb-10" @value={{this.changeset.cleartextPassword}} @name="cleartextPassword" @tabindex="3"/>
+                    <Input class="form-control secret mb-10" @value={{this.changeset.cleartextPassword}} @name="cleartextPassword" @tabindex="3" autocomplete="off"/>
                     <PasswordStrengthMeter @password={{this.changeset.cleartextPassword}}/>
                   </div>
                 </div>

--- a/frontend/translations/ch-be.yml
+++ b/frontend/translations/ch-be.yml
@@ -38,6 +38,7 @@ ch_be:
   team: Team
   move: Bewegä
   here: hiä
+  new: Nöi
   save: Spichere
   close: Schliesse
   user: Benutzer
@@ -81,7 +82,7 @@ ch_be:
     title: Suechä
     index:
       hi_user: "Hallo %{username}! Suechsch es Passwort?"
-      no_results_found: keni Ergäbniss gfunde
+      no_results_found: äuä nüt gfunde
       type_to_search: Tippe für z sueche...
 
   accounts:
@@ -95,7 +96,8 @@ ch_be:
       title: Account editiere
       random_password: Zuefäuigs Passwort
       edit_password_placeholder: Klickä oder fokusierä für Igab ...
-      team_placeholder: Wähl es Team us
+      team_placeholder: Wähl äs Team us
+      folder_placeholder: Wähl ä Ordner us
       password_strength: Passwort Sterchi
       password_strengths:
         weak: Schwach
@@ -118,9 +120,15 @@ ch_be:
     maintenance_tasks:
       index:
         title: Wartigsufgabe
-        unavailable: Keni Wartigsufgabe verfüegbar
+        unavailable: Äuä ke Wartigsufgabe verfüegbar
         maintenance_task: Wartigsufgab
         run: Usfüehre
+        prepare: Vorbereite
+        execute: Usführe
+        executed_at: Usgführt am
+        status: Status
+        output: Output
+        executor: Usführer
     settings:
       index:
         title: Istellige bearbeite
@@ -157,7 +165,7 @@ ch_be:
         title: Lischtä vo aune Cryptopus Benutzer
         username: Benutzernamä
         name: Namä
-        ldap_uid: LDAP UID
+        provider_uid: PROVIDER UID
         last_login_at: Letschti Ameudig am
         last_login_from: Letschti Ameudig vo
         admin: Admin
@@ -170,6 +178,13 @@ ch_be:
         destroy: Benutzer lösche
       new:
         title: Nöie Benutzer
+    teams:
+      index:
+        title: Teams
+        teamname: Teamname
+        num_folders: Ahzahl Ordner
+        num_accounts: Ahzahl Accounts
+        members: Mitglieder
 
   folders:
     title: Ordner
@@ -197,6 +212,11 @@ ch_be:
       title: Amäudä
       description: Bitte gib di Benutzername u dis Passwort i zum z'Cryptopus chönne z bruche.
       submit: Amäudä
+    local:
+      new:
+        title: Amäudä
+        description: Bitte gib di Benutzername u dis Passwort i zum z'Cryptopus chönne z bruche.
+        submit: Amäudä
     destroy:
       title: Abmäudä
       message: Ufwiderluege
@@ -303,7 +323,7 @@ ch_be:
           root: Dr Root cha nid glösche werde
         update:
           root: Dr Root cha nid aktualisiert werde
-          ldap: Dr Ldap User cha nid aktualisiert werde
+          not_db: Nume Db User chöi aktualisiert werde
       maintenance_tasks:
         succeed: D Wartigsufgab isch erfougrich düregfüehrt worde
         failed: D Wartigsufgab isch gschiteret. Lueg i de Logs für me Details nache.

--- a/frontend/translations/de.yml
+++ b/frontend/translations/de.yml
@@ -93,6 +93,12 @@ de:
         unavailable: Keine Wartungsaufgaben vorhanden
         maintenance_task: Wartungsaufgabe
         run: Ausführen
+        prepare: Vorbereiten
+        execute: Ausführen
+        executed_at: Ausgeführt am
+        status: Status
+        output: Output
+        executor: Ausführer
     settings:
       index:
         title: Einstellungen bearbeiten
@@ -131,7 +137,7 @@ de:
         title: Liste aller Cryptopus Benutzer
         username: Benutzername
         name: Name
-        ldap_uid: LDAP UID
+        provider_uid: PROVIDER UID
         last_login_at: Letzte Anmeldung am
         last_login_from: Letzte Anmeldung von
         admin: Admin
@@ -147,6 +153,11 @@ de:
     teams:
       index:
         title: Teams
+        teamname: Teamname
+        num_folders: Anzahl Ordner
+        num_accounts: Anzahl Accounts
+        members: Mitglieder
+
     user_roles:
       user: Benutzer
       conf_admin: Conf Admin
@@ -178,6 +189,11 @@ de:
       title: Anmelden
       description: Bitte geben Sie Ihren Benutzernamen und Ihr Passwort ein um Cryptopus zu verwenden.
       submit: Anmelden
+    local:
+      new:
+        title: Anmelden
+        description: Bitte geben Sie Ihren Benutzernamen und Ihr Passwort ein um Cryptopus zu verwenden.
+        submit: Anmelden
     destroy:
       title: Abmelden
       message: Aufwiedersehen
@@ -312,7 +328,7 @@ de:
           root: Root kann nicht gelöscht werden
         update:
           root: Root kann nicht aktualisiert werden
-          ldap: Ldap User kann nicht aktualisiert werden
+          not_db: Nur Db User können aktualisiert werden
       maintenance_tasks:
         succeed: Wartungsaufgabe wurde erfolgreich durchgeführt
         failed: Wartungsaufgabe ist gescheitert. Siehe Logs für mehr Details.

--- a/frontend/translations/en.yml
+++ b/frontend/translations/en.yml
@@ -94,6 +94,10 @@ en:
         run: execute
         prepare: prepare
         execute: execute
+        executed_at: Executed At
+        status: Status
+        output: Output
+        executor: Executor
     settings:
       index:
         title: Edit Settings
@@ -148,6 +152,10 @@ en:
     teams:
       index:
         title: Teams
+        teamname: Teamname
+        num_folders: Number of Folders
+        num_accounts: Number of Accounts
+        members: Members
     user_roles:
       user: User
       conf_admin: Conf Admin

--- a/frontend/translations/fr.yml
+++ b/frontend/translations/fr.yml
@@ -67,6 +67,12 @@ fr:
       random_password: Mot de passe aléatoire
       team_placeholder: Choisissez une équipe
       folder_placeholder: Choisissez un dossier
+      password_strength: Fiabilité du mot de passe
+      password_strengths:
+        weak: Faible
+        fair: Approprié
+        good: Bien
+        strong: Fort
     show:
       title: "Compte: %{account_name}"
       last_change: "Dernière mise à jour il ya %{time_ago}"
@@ -85,6 +91,12 @@ fr:
         unavailable: Il n'y a pas de tâches de maintenance
         maintenance_task: Tâche de maintenance
         run: effectuer
+        prepare: préparer
+        execute: effectuer
+        executed_at: Effectué à
+        status: Statut
+        output: Output
+        executor: Effectueur
     settings:
       index:
         title: Modifier les paramètres
@@ -122,7 +134,7 @@ fr:
         title: La Liste de toutes les utilisateurs
         username: Nom d'utilisateur
         name: Nom
-        ldap_uid: LDAP UID
+        provider_uid: PROVIDER UID
         last_login_at: Dernière connexion à
         last_login_from: Dernière connexion de
         admin: Admin
@@ -138,6 +150,10 @@ fr:
     teams:
       index:
         title: Teams
+        teamname: Nom de l'équipe
+        num_folders: Nombre de dossiers
+        num_accounts: Nombre de comptes
+        members: Membres
     user_roles:
       user: Utilisateur
       conf_admin: Conf Admin
@@ -169,6 +185,11 @@ fr:
       title: Identifiez-vous
       description: S'il vous plaît entrer un nom d'utilisateur valide et mot de passe.
       submit: S'identifier
+    local:
+      new:
+        title: Identifiez-vous
+        description: S'il vous plaît entrer un nom d'utilisateur valide et mot de passe.
+        submit: S'identifier
     destroy:
       title: Déconnexion
       message: Au revoir
@@ -299,7 +320,7 @@ fr:
           root: Root ne peut pas être supprimé
         update:
           root: Root ne peuvent pas être mis à jour
-          ldap: Ldap utilisateur ne peuvent pas être mis à jour
+          not_db: Utilisateur non Db ne peut pas être mis à jour
       maintenance_tasks:
         succeed: La tâche a été exécutée avec succès..
         failed: La tâche a échoué. Consultez les journaux pour plus d'informations.
@@ -358,6 +379,7 @@ fr:
         surname: Nom de famille
       account:
         account: Compte
+        account_name: Nom du compte
         username: Nom d'utilisateur
         password: Mot de passe
         description: Description

--- a/spec/integration/legacy_routes/redirect_url_spec.rb
+++ b/spec/integration/legacy_routes/redirect_url_spec.rb
@@ -185,4 +185,17 @@ describe LegacyRoutes::RedirectUrl do
 
     assert_redirected_to team_folder_path(team1, folder1)
   end
+
+  context 'if not logged in' do
+    it 'should set locale to default and redirect to login' do
+      team1 = teams(:team1)
+      folder1 = folders(:folder1)
+
+      invalid_account_url = "/teams/#{team1.id}/folders/#{folder1.id}/accounts"
+      get invalid_account_url
+
+      expect(I18n.locale).to eq(:en)
+      assert_redirected_to session_new_path
+    end
+  end
 end

--- a/spec/system/account_modal_system_spec.rb
+++ b/spec/system/account_modal_system_spec.rb
@@ -38,7 +38,7 @@ describe 'AccountModal', type: :system, js: true do
 
 
     expect(page.find_field('cleartextPassword')).to be_present
-    check_password_meter('password', '10')
+    check_password_meter('password', '25')
     check_password_meter('password11', '25')
     check_password_meter('cryptopu', '50')
     check_password_meter('cryptopus1', '75')


### PR DESCRIPTION
Fix some minor issues.

- Translations were missing, in particular for Berndeutsch
- When not logged in and trying to call legacy route, but without locale, error occured.
- Autocomplete for pw field disabled and pw meter logic improved.