### PR TITLE
Add security.txt to Cryptopus Homepage

### DIFF
--- a/frontend/public/security.txt
+++ b/frontend/public/security.txt
@@ -1,0 +1,1 @@
+Contact: mailto: security@puzzle.ch


### PR DESCRIPTION
This PR adds a security.txt file to the Cryptopus homepage. 
The result should be: <cryptopus-url>/security.txt, similar to the robots.txt. 
But the security.txt has another purpose. The security.txt is a standard file that provides a contact for security researchers, similiar to the GitHub security policy, in case they find a vulnerability.
For further info about the security.txt see: https://securitytxt.org/