### PR TITLE
Sort teams ignoring uppercase and umlauts

### DIFF
--- a/frontend/app/services/nav-service.js
+++ b/frontend/app/services/nav-service.js
@@ -15,9 +15,7 @@ export default class NavService extends Service {
 
   get sortedTeams() {
     return this.availableTeams.toArray().sort((a, b) => {
-      if (a.name < b.name) return -1;
-      if (a.name > b.name) return 1;
-      return 0;
+      return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
     });
   }
 


### PR DESCRIPTION
In my cryptopus account, the `hitobito` team is listed after the `Quartieridee` and `UZH` teams. This PR changes the sorting algorithm to disregard upper-/lowercase. It also uses `localeCompare` such that umlauts (ä, ö, ü, é, ...) are sorted correctly based on the current browser locale. This is a built-in feature of ECMAScript and supported by all browsers: https://caniuse.com/localecompare

(I haven't manually tested my implementation, please do test it during the review)