### PR TITLE
Feature/541 provide sorting in admin/users view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ BUILD
 .rake_tasks~
 .tags
 .tags_swap
+.vscode
 
 # Ignore application configuration
 /config/application.yml

--- a/frontend/app/components/admin/user/table.js
+++ b/frontend/app/components/admin/user/table.js
@@ -9,7 +9,7 @@ export default class AdminUsersTable extends Component {
   @tracked
   users = [];
 
-  sortedBy = "";
+  sortedBy = "username";
 
   constructor() {
     super(...arguments);
@@ -80,8 +80,8 @@ export default class AdminUsersTable extends Component {
             } else if (userB.lastLoginAt == null) {
               return -1;
             } else {
-              if (userA.lastLoginAt < userB.lastLoginAt) return -1 * asc;
-              if (userA.lastLoginAt > userB.lastLoginAt) return 1 * asc;
+              if (userA.lastLoginAt > userB.lastLoginAt) return -1 * asc;
+              if (userA.lastLoginAt < userB.lastLoginAt) return 1 * asc;
               return 0;
             }
           case "last_login_from":
@@ -99,7 +99,15 @@ export default class AdminUsersTable extends Component {
           case "auth":
             if (userA.auth < userB.auth) return -1 * asc;
             if (userA.auth > userB.auth) return 1 * asc;
-            return 0;
+            else {
+              if (userA.providerUid == null && userB.providerUid == null)
+                return 0;
+              else if (userA.providerUid == null) return 1 * asc;
+              else if (userB.providerUid == null) return -1 * asc;
+              else if (userA.providerUid < userB.providerUid) return 1 * asc;
+              else if (userA.providerUid > userB.providerUid) return -1 * asc;
+              return 0;
+            }
           case "role":
             if (userA.role < userB.role) return -1 * asc;
             if (userA.role > userB.role) return 1 * asc;

--- a/frontend/app/components/admin/user/table.js
+++ b/frontend/app/components/admin/user/table.js
@@ -16,14 +16,15 @@ export default class AdminUsersTable extends Component {
 
     if (this.args.users) {
       this.users = this.args.users
-      .toArray().filter((user) => {
+        .toArray()
+        .filter((user) => {
           return !user.isDeleted;
         })
         .sort((userA, userB) => {
           if (userA.username < userB.username) return -1;
           if (userA.username > userB.username) return 1;
-        return 0;
-      });
+          return 0;
+        });
     }
   }
 

--- a/frontend/app/components/admin/user/table.js
+++ b/frontend/app/components/admin/user/table.js
@@ -21,8 +21,11 @@ export default class AdminUsersTable extends Component {
           return !user.isDeleted;
         })
         .sort((userA, userB) => {
-          return userA.username < userB.username ? -1 : 1
-          return 0;
+          return userA.username == userB.username
+            ? 0
+            : userA.username < userB.username
+            ? -1
+            : 1;
         });
     }
   }

--- a/frontend/app/components/admin/user/table.js
+++ b/frontend/app/components/admin/user/table.js
@@ -34,15 +34,15 @@ export default class AdminUsersTable extends Component {
 
   @action
   sortBy(attribute) {
-    this.users.sort((userA, userB) => {
+    this.users = this.users.sort((userA, userB) => {
       switch (attribute.toString()) {
         case "username":
           if (userA.username < userB.username) return -1;
           if (userA.username > userB.username) return 1;
           return 0;
-        case "surname":
-          if (userA.surname < userB.surname) return -1;
-          if (userA.surname > userB.surname) return 1;
+        case "givenname":
+          if (userA.givenname < userB.givenname) return -1;
+          if (userA.givenname > userB.givenname) return 1;
           return 0;
         case "last_login_at": // works but could be prettier
           if (userA.lastLoginAt == null && userB.lastLoginAt == null) {

--- a/frontend/app/components/admin/user/table.js
+++ b/frontend/app/components/admin/user/table.js
@@ -21,8 +21,7 @@ export default class AdminUsersTable extends Component {
           return !user.isDeleted;
         })
         .sort((userA, userB) => {
-          if (userA.username < userB.username) return -1;
-          if (userA.username > userB.username) return 1;
+          return userA.username < userB.username ? -1 : 1
           return 0;
         });
     }

--- a/frontend/app/components/admin/user/table.js
+++ b/frontend/app/components/admin/user/table.js
@@ -28,20 +28,6 @@ export default class AdminUsersTable extends Component {
     }
   }
 
-  /*
-  get sortedUsers() {
-    return this.users
-      .filter((user) => {
-        return !user.isDeleted;
-      })
-      .sort((userA, userB) => {
-        if (userA.username < userB.username) return -1;
-        if (userA.username > userB.username) return 1;
-        return 0;
-      });
-  }
-  */
-
   @action
   removeUser(user) {
     this.users.removeObject(user);
@@ -104,8 +90,8 @@ export default class AdminUsersTable extends Component {
                 return 0;
               else if (userA.providerUid == null) return 1 * asc;
               else if (userB.providerUid == null) return -1 * asc;
-              else if (userA.providerUid < userB.providerUid) return 1 * asc;
-              else if (userA.providerUid > userB.providerUid) return -1 * asc;
+              else if (userA.providerUid < userB.providerUid) return -1 * asc;
+              else if (userA.providerUid > userB.providerUid) return 1 * asc;
               return 0;
             }
           case "role":

--- a/frontend/app/components/admin/user/table.js
+++ b/frontend/app/components/admin/user/table.js
@@ -53,9 +53,24 @@ export default class AdminUsersTable extends Component {
       .sort((userA, userB) => {
         switch (attribute.toString()) {
           case "username":
-            return this.sortAttributes(userA.username, userB.username, asc);
+            return this.sortAttributes(
+              userA.username.toLowerCase(),
+              userB.username.toLowerCase(),
+              asc
+            );
           case "givenname":
-            return this.sortAttributes(userA.givenname, userB.givenname, asc);
+            return userA.givenname.toLowerCase() ==
+              userB.givenname.toLowerCase()
+              ? this.sortAttributes(
+                  userA.surname.toLowerCase(),
+                  userB.surname.toLowerCase(),
+                  asc
+                )
+              : this.sortAttributes(
+                  userA.givenname.toLowerCase(),
+                  userB.givenname.toLowerCase(),
+                  asc
+                );
           case "last_login_at":
             if (userA.lastLoginAt == null || userB.lastLoginAt == null) {
               return this.sortWithNull(userA.lastLoginAt, userB.lastLoginAt);

--- a/frontend/app/components/admin/user/table.js
+++ b/frontend/app/components/admin/user/table.js
@@ -9,12 +9,25 @@ export default class AdminUsersTable extends Component {
   @tracked
   users = [];
 
+  sortedBy = "";
+
   constructor() {
     super(...arguments);
 
-    if (this.args.users) this.users = this.args.users.toArray();
+    if (this.args.users) {
+      this.users = this.args.users
+      .toArray().filter((user) => {
+          return !user.isDeleted;
+        })
+        .sort((userA, userB) => {
+          if (userA.username < userB.username) return -1;
+          if (userA.username > userB.username) return 1;
+        return 0;
+      });
+    }
   }
 
+  /*
   get sortedUsers() {
     return this.users
       .filter((user) => {
@@ -26,6 +39,7 @@ export default class AdminUsersTable extends Component {
         return 0;
       });
   }
+  */
 
   @action
   removeUser(user) {
@@ -34,49 +48,62 @@ export default class AdminUsersTable extends Component {
 
   @action
   sortBy(attribute) {
-    this.users = this.users.sort((userA, userB) => {
-      switch (attribute.toString()) {
-        case "username":
-          if (userA.username < userB.username) return -1;
-          if (userA.username > userB.username) return 1;
-          return 0;
-        case "givenname":
-          if (userA.givenname < userB.givenname) return -1;
-          if (userA.givenname > userB.givenname) return 1;
-          return 0;
-        case "last_login_at": // works but could be prettier
-          if (userA.lastLoginAt == null && userB.lastLoginAt == null) {
+    let asc;
+    if (attribute == this.sortedBy) {
+      asc = -1;
+      this.sortedBy = "";
+    } else {
+      asc = 1;
+      this.sortedBy = attribute.toString();
+    }
+
+    this.users = this.users
+      .filter((user) => {
+        return !user.isDeleted;
+      })
+      .sort((userA, userB) => {
+        switch (attribute.toString()) {
+          case "username":
+            if (userA.username < userB.username) return -1 * asc;
+            if (userA.username > userB.username) return 1 * asc;
             return 0;
-          } else if (userA.lastLoginAt == null) {
-            return 1;
-          } else if (userB.lastLoginAt == null) {
-            return -1;
-          } else {
-            if (userA.lastLoginAt < userB.lastLoginAt) return -1;
-            if (userA.lastLoginAt > userB.lastLoginAt) return 1;
+          case "givenname":
+            if (userA.givenname < userB.givenname) return -1 * asc;
+            if (userA.givenname > userB.givenname) return 1 * asc;
             return 0;
-          }
-        case "last_login_from":
-          if (userA.lastLoginFrom == null && userB.lastLoginFrom == null) {
+          case "last_login_at": // works but could be prettier
+            if (userA.lastLoginAt == null && userB.lastLoginAt == null) {
+              return 0;
+            } else if (userA.lastLoginAt == null) {
+              return 1;
+            } else if (userB.lastLoginAt == null) {
+              return -1;
+            } else {
+              if (userA.lastLoginAt < userB.lastLoginAt) return -1 * asc;
+              if (userA.lastLoginAt > userB.lastLoginAt) return 1 * asc;
+              return 0;
+            }
+          case "last_login_from":
+            if (userA.lastLoginFrom == null && userB.lastLoginFrom == null) {
+              return 0;
+            } else if (userA.lastLoginFrom == null) {
+              return 1;
+            } else if (userB.lastLoginFrom == null) {
+              return -1;
+            } else {
+              if (userA.lastLoginFrom < userB.lastLoginFrom) return -1 * asc;
+              if (userA.lastLoginFrom > userB.lastLoginFrom) return 1 * asc;
+              return 0;
+            }
+          case "auth":
+            if (userA.auth < userB.auth) return -1 * asc;
+            if (userA.auth > userB.auth) return 1 * asc;
             return 0;
-          } else if (userA.lastLoginFrom == null) {
-            return 1;
-          } else if (userB.lastLoginFrom == null) {
-            return -1;
-          } else {
-            if (userA.lastLoginFrom < userB.lastLoginFrom) return -1;
-            if (userA.lastLoginFrom > userB.lastLoginFrom) return 1;
+          case "role":
+            if (userA.role < userB.role) return -1 * asc;
+            if (userA.role > userB.role) return 1 * asc;
             return 0;
-          }
-        case "auth":
-          if (userA.auth < userB.auth) return -1;
-          if (userA.auth > userB.auth) return 1;
-          return 0;
-        case "role":
-          if (userA.role < userB.role) return -1;
-          if (userA.role > userB.role) return 1;
-          return 0;
-      }
-    });
+        }
+      });
   }
 }

--- a/frontend/app/components/admin/user/table.js
+++ b/frontend/app/components/admin/user/table.js
@@ -53,54 +53,47 @@ export default class AdminUsersTable extends Component {
       .sort((userA, userB) => {
         switch (attribute.toString()) {
           case "username":
-            if (userA.username < userB.username) return -1 * asc;
-            if (userA.username > userB.username) return 1 * asc;
-            return 0;
+            return this.sortAttributes(userA.username, userB.username, asc);
           case "givenname":
-            if (userA.givenname < userB.givenname) return -1 * asc;
-            if (userA.givenname > userB.givenname) return 1 * asc;
-            return 0;
-          case "last_login_at": // works but could be prettier
-            if (userA.lastLoginAt == null && userB.lastLoginAt == null) {
-              return 0;
-            } else if (userA.lastLoginAt == null) {
-              return 1;
-            } else if (userB.lastLoginAt == null) {
-              return -1;
+            return this.sortAttributes(userA.givenname, userB.givenname, asc);
+          case "last_login_at":
+            if (userA.lastLoginAt == null || userB.lastLoginAt == null) {
+              return this.sortWithNull(userA.lastLoginAt, userB.lastLoginAt);
             } else {
-              if (userA.lastLoginAt > userB.lastLoginAt) return -1 * asc;
-              if (userA.lastLoginAt < userB.lastLoginAt) return 1 * asc;
-              return 0;
+              return this.sortAttributes(
+                userA.lastLoginAt,
+                userB.lastLoginAt,
+                asc * -1
+              );
             }
           case "last_login_from":
-            if (userA.lastLoginFrom == null && userB.lastLoginFrom == null) {
-              return 0;
-            } else if (userA.lastLoginFrom == null) {
-              return 1;
-            } else if (userB.lastLoginFrom == null) {
-              return -1;
+            if (userA.lastLoginFrom == null || userB.lastLoginFrom == null) {
+              return this.sortWithNull(
+                userA.lastLoginFrom,
+                userB.lastLoginFrom
+              );
             } else {
-              if (userA.lastLoginFrom < userB.lastLoginFrom) return -1 * asc;
-              if (userA.lastLoginFrom > userB.lastLoginFrom) return 1 * asc;
-              return 0;
+              return this.sortAttributes(
+                userA.lastLoginFrom,
+                userB.lastLoginFrom,
+                asc
+              );
             }
           case "auth":
-            if (userA.auth < userB.auth) return -1 * asc;
-            if (userA.auth > userB.auth) return 1 * asc;
-            else {
-              if (userA.providerUid == null && userB.providerUid == null)
-                return 0;
-              else if (userA.providerUid == null) return 1 * asc;
-              else if (userB.providerUid == null) return -1 * asc;
-              else if (userA.providerUid < userB.providerUid) return -1 * asc;
-              else if (userA.providerUid > userB.providerUid) return 1 * asc;
-              return 0;
-            }
+            return userA.auth == userB.auth
+              ? this.sortWithNull(userA.providerUid, userB.providerUid)
+              : this.sortAttributes(userA.auth, userB.auth, asc);
           case "role":
-            if (userA.role < userB.role) return -1 * asc;
-            if (userA.role > userB.role) return 1 * asc;
-            return 0;
+            return this.sortAttributes(userA.role, userB.role, asc);
         }
       });
+  }
+
+  sortAttributes(userA, userB, asc) {
+    return userA == userB ? 0 : userA < userB ? -1 * asc : 1 * asc;
+  }
+
+  sortWithNull(userA, userB) {
+    return userA == null && userB == null ? 0 : userA == null ? 1 : -1;
   }
 }

--- a/frontend/app/components/admin/user/table.js
+++ b/frontend/app/components/admin/user/table.js
@@ -31,4 +31,52 @@ export default class AdminUsersTable extends Component {
   removeUser(user) {
     this.users.removeObject(user);
   }
+
+  @action
+  sortBy(attribute) {
+    this.users.sort((userA, userB) => {
+      switch (attribute.toString()) {
+        case "username":
+          if (userA.username < userB.username) return -1;
+          if (userA.username > userB.username) return 1;
+          return 0;
+        case "surname":
+          if (userA.surname < userB.surname) return -1;
+          if (userA.surname > userB.surname) return 1;
+          return 0;
+        case "last_login_at": // works but could be prettier
+          if (userA.lastLoginAt == null && userB.lastLoginAt == null) {
+            return 0;
+          } else if (userA.lastLoginAt == null) {
+            return 1;
+          } else if (userB.lastLoginAt == null) {
+            return -1;
+          } else {
+            if (userA.lastLoginAt < userB.lastLoginAt) return -1;
+            if (userA.lastLoginAt > userB.lastLoginAt) return 1;
+            return 0;
+          }
+        case "last_login_from":
+          if (userA.lastLoginFrom == null && userB.lastLoginFrom == null) {
+            return 0;
+          } else if (userA.lastLoginFrom == null) {
+            return 1;
+          } else if (userB.lastLoginFrom == null) {
+            return -1;
+          } else {
+            if (userA.lastLoginFrom < userB.lastLoginFrom) return -1;
+            if (userA.lastLoginFrom > userB.lastLoginFrom) return 1;
+            return 0;
+          }
+        case "auth":
+          if (userA.auth < userB.auth) return -1;
+          if (userA.auth > userB.auth) return 1;
+          return 0;
+        case "role":
+          if (userA.role < userB.role) return -1;
+          if (userA.role > userB.role) return 1;
+          return 0;
+      }
+    });
+  }
 }

--- a/frontend/app/templates/components/admin/user/table.hbs
+++ b/frontend/app/templates/components/admin/user/table.hbs
@@ -1,17 +1,48 @@
 <table class="table table-striped mb-15">
   <thead>
     <tr>
-      <th>{{t "admin.users.index.username"}}</th>
-      <th>{{t "admin.users.index.name"}}</th>
-      <th>{{t "admin.users.index.last_login_at"}}</th>
-      <th>{{t "admin.users.index.last_login_from"}}</th>
-      <th>{{t "admin.users.index.auth"}} {{t "admin.users.index.provider_uid"}}</th>
-      <th width="200">{{t "admin.users.index.role"}}</th>
+      <th>
+        {{t "admin.users.index.username"}}
+        <span role="button" {{action "sortBy" "username"}}>
+          <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
+        </span>
+      </th>
+      <th>
+        {{t "admin.users.index.name"}}
+        <span role="button" {{action "sortBy" "givenname"}}>
+          <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
+        </span>
+      </th>
+      <th>
+        {{t "admin.users.index.last_login_at"}}
+        <span role="button" {{action "sortBy" "last_login_at"}}>
+          <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
+        </span>
+      </th>
+      <th>
+        {{t "admin.users.index.last_login_from"}}
+        <span role="button" {{action "sortBy" "last_login_from"}}>
+          <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
+        </span>
+      </th>
+      <th>
+        {{t "admin.users.index.auth"}}
+        {{t "admin.users.index.provider_uid"}}
+        <span role="button" {{action "sortBy" "auth"}}>
+          <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
+        </span>
+      </th>
+      <th width="200">
+        {{t "admin.users.index.role"}}
+        <span role="button" {{action "sortBy" "role"}}>
+          <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
+        </span>
+      </th>
       <th>{{t "admin.users.index.action"}}</th>
     </tr>
   </thead>
   <tbody>
-    {{#each this.sortedUsers as |user|}}
+    {{#each this.users as |user|}}
       <Admin::User::TableRow @user={{user}} @onRemove={{this.removeUser}} />
     {{/each}}
   </tbody>

--- a/frontend/app/templates/components/admin/user/table.hbs
+++ b/frontend/app/templates/components/admin/user/table.hbs
@@ -3,37 +3,37 @@
     <tr>
       <th>
         {{t "admin.users.index.username"}}
-        <span role="button" {{action "sortBy" "username"}}>
+        <span role="button" {{action "sortBy" "username"}} id="sort-username">
           <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
         </span>
       </th>
       <th>
         {{t "admin.users.index.name"}}
-        <span role="button" {{action "sortBy" "givenname"}}>
+        <span role="button" {{action "sortBy" "givenname"}} id="sort-name">
           <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
         </span>
       </th>
       <th>
         {{t "admin.users.index.last_login_at"}}
-        <span role="button" {{action "sortBy" "last_login_at"}}>
+        <span role="button" {{action "sortBy" "last_login_at"}} id="sort-login-a"t>
           <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
         </span>
       </th>
       <th>
         {{t "admin.users.index.last_login_from"}}
-        <span role="button" {{action "sortBy" "last_login_from"}}>
+        <span role="button" {{action "sortBy" "last_login_from"}} id="sort-login-from">
           <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
         </span>
       </th>
       <th>
         {{t "admin.users.index.auth"}} {{t "admin.users.index.provider_uid"}}
-        <span role="button" {{action "sortBy" "auth"}}>
+        <span role="button" {{action "sortBy" "auth"}} id="sort-auth">
           <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
         </span>
       </th>
       <th width="200">
         {{t "admin.users.index.role"}}
-        <span role="button" {{action "sortBy" "role"}}>
+        <span role="button" {{action "sortBy" "role"}} id="sort-role">
           <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
         </span>
       </th>

--- a/frontend/app/templates/components/admin/user/table.hbs
+++ b/frontend/app/templates/components/admin/user/table.hbs
@@ -26,8 +26,7 @@
         </span>
       </th>
       <th>
-        {{t "admin.users.index.auth"}}
-        {{t "admin.users.index.provider_uid"}}
+        {{t "admin.users.index.auth"}} {{t "admin.users.index.provider_uid"}}
         <span role="button" {{action "sortBy" "auth"}}>
           <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
         </span>

--- a/frontend/app/templates/components/admin/user/table.hbs
+++ b/frontend/app/templates/components/admin/user/table.hbs
@@ -15,7 +15,7 @@
       </th>
       <th>
         {{t "admin.users.index.last_login_at"}}
-        <span role="button" {{action "sortBy" "last_login_at"}} id="sort-login-a"t>
+        <span role="button" {{action "sortBy" "last_login_at"}} id="sort-login-at">
           <img class="icon-big-button float-right" src="/assets/images/angle-down-blue.svg" alt="v">
         </span>
       </th>

--- a/frontend/tests/integration/components/admin/user/table-test.js
+++ b/frontend/tests/integration/components/admin/user/table-test.js
@@ -22,12 +22,18 @@ module("Integration | Component | admin/user/table", function (hooks) {
       username: "Bob",
       givenname: "Bobby",
       role: "admin",
+      lastLoginAt: "11.03.2022 03:03",
+      lastLoginFrom: "xyz",
+      auth: "db : 2",
       isDeleted: false
     },
     {
       username: "Alice",
       givenname: "Allison",
       role: "user",
+      lastLoginAt: "17.03.2022 06:56",
+      lastLoginFrom: "abc",
+      auth: "db : 1",
       isDeleted: false
     },
     {
@@ -72,18 +78,65 @@ module("Integration | Component | admin/user/table", function (hooks) {
     text = this.element.textContent.trim();
 
     assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
-    assert.ok(text.indexOf("Fred") == -1);
 
     await click('span[id="sort-name"]');
     text = this.element.textContent.trim();
 
     assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
-    assert.ok(text.indexOf("Fred") == -1);
 
     await click('span[id="sort-name"]');
     text = this.element.textContent.trim();
 
     assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
-    assert.ok(text.indexOf("Fred") == -1);
+
+    await click('span[id="sort-username"]');
+    text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
+
+    await click('span[id="sort-username"]');
+    text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
+
+    await click('span[id="sort-role"]');
+    text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
+
+    await click('span[id="sort-role"]');
+    text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
+
+    await click('span[id="sort-login-at"]');
+    text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
+
+    await click('span[id="sort-login-at"]');
+    text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
+
+    await click('span[id="sort-login-from"]');
+    text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
+
+    await click('span[id="sort-login-from"]');
+    text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
+
+    await click('span[id="sort-auth"]');
+    text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
+
+    await click('span[id="sort-auth"]');
+    text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
   });
 });

--- a/frontend/tests/integration/components/admin/user/table-test.js
+++ b/frontend/tests/integration/components/admin/user/table-test.js
@@ -32,7 +32,7 @@ module("Integration | Component | admin/user/table", function (hooks) {
       username: "Alice",
       givenname: "Allison",
       role: "user",
-      lastLoginAt: "17.03.2022 06:56",
+      lastLoginAt: "12.03.2022 06:56",
       lastLoginFrom: "111.123.22.1",
       auth: "db",
       providerUid: 1,
@@ -72,71 +72,34 @@ module("Integration | Component | admin/user/table", function (hooks) {
     let text = this.element.textContent.trim();
 
     assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
-    assert.ok(text.indexOf("Fred") == -1);
 
-    await click('span[id="sort-username"]');
-    text = this.element.textContent.trim();
+    assert.ok(proveDescOrder("sort-username", "Alice", "Bob", this));
 
-    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
+    assert.ok(proveAscOrder("sort-name", "Alice", "Bob", this));
+    assert.ok(proveDescOrder("sort-name", "Alice", "Bob", this));
 
-    await click('span[id="sort-name"]');
-    text = this.element.textContent.trim();
+    assert.ok(proveAscOrder("sort-role", "admin", "user", this));
+    assert.ok(proveDescOrder("sort-role", "admin", "user", this));
 
-    assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
+    assert.ok(proveAscOrder("sort-auth", "Alice", "Bob", this));
+    assert.ok(proveDescOrder("sort-auth", "Alice", "Bob", this));
 
-    await click('span[id="sort-name"]');
-    text = this.element.textContent.trim();
+    assert.ok(proveAscOrder("sort-login-at", "Alice", "Bob", this));
+    assert.ok(proveDescOrder("sort-login-at", "Alice", "Bob", this));
 
-    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
+    assert.ok(proveAscOrder("sort-login-from", "Alice", "Bob", this));
+    assert.ok(proveDescOrder("sort-login-from", "Alice", "Bob", this));
 
-    await click('span[id="sort-username"]');
-    text = this.element.textContent.trim();
+    async function proveAscOrder(elementId, value1, value2, testObject) {
+      await click(`span[id='${elementId}']`);
+      text = testObject.element.textContent.trim();
+      return text.indexOf(value1) < text.indexOf(value2);
+    }
 
-    assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
-
-    await click('span[id="sort-username"]');
-    text = this.element.textContent.trim();
-
-    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
-
-    await click('span[id="sort-role"]');
-    text = this.element.textContent.trim();
-
-    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
-
-    await click('span[id="sort-role"]');
-    text = this.element.textContent.trim();
-
-    assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
-
-    await click('span[id="sort-login-at"]');
-    text = this.element.textContent.trim();
-
-    assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
-
-    await click('span[id="sort-login-at"]');
-    text = this.element.textContent.trim();
-
-    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
-
-    await click('span[id="sort-login-from"]');
-    text = this.element.textContent.trim();
-
-    assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
-
-    await click('span[id="sort-login-from"]');
-    text = this.element.textContent.trim();
-
-    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
-
-    await click('span[id="sort-auth"]');
-    text = this.element.textContent.trim();
-
-    assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
-
-    await click('span[id="sort-auth"]');
-    text = this.element.textContent.trim();
-
-    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
+    async function proveDescOrder(elementId, value1, value2, testObject) {
+      await click(`span[id='${elementId}']`);
+      text = testObject.element.textContent.trim();
+      return text.indexOf(value1) > text.indexOf(value2);
+    }
   });
 });

--- a/frontend/tests/integration/components/admin/user/table-test.js
+++ b/frontend/tests/integration/components/admin/user/table-test.js
@@ -23,8 +23,9 @@ module("Integration | Component | admin/user/table", function (hooks) {
       givenname: "Bobby",
       role: "admin",
       lastLoginAt: "11.03.2022 03:03",
-      lastLoginFrom: "xyz",
-      auth: "db : 2",
+      lastLoginFrom: "111.123.22.2",
+      auth: "db",
+      providerUid: 2,
       isDeleted: false
     },
     {
@@ -32,14 +33,13 @@ module("Integration | Component | admin/user/table", function (hooks) {
       givenname: "Allison",
       role: "user",
       lastLoginAt: "17.03.2022 06:56",
-      lastLoginFrom: "abc",
-      auth: "db : 1",
+      lastLoginFrom: "111.123.22.1",
+      auth: "db",
+      providerUid: 1,
       isDeleted: false
     },
     {
       username: "Fred",
-      givenname: "Alfred",
-      role: "conf_admin",
       isDeleted: true
     }
   ];

--- a/frontend/tests/integration/components/admin/user/table-test.js
+++ b/frontend/tests/integration/components/admin/user/table-test.js
@@ -1,6 +1,6 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
-import { render } from "@ember/test-helpers";
+import { render, click } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setLocale } from "ember-intl/test-support";
 import ENV from "../../../../../config/environment";
@@ -17,22 +17,28 @@ module("Integration | Component | admin/user/table", function (hooks) {
     ENV.currentUserGivenname = null;
   });
 
-  test("it renders with data", async function (assert) {
-    const users = [
-      {
-        username: "Bob",
-        isDeleted: false
-      },
-      {
-        username: "Alice",
-        isDeleted: false
-      },
-      {
-        username: "Fred",
-        isDeleted: true
-      }
-    ];
+  const users = [
+    {
+      username: "Bob",
+      givenname: "Bobby",
+      role: "admin",
+      isDeleted: false
+    },
+    {
+      username: "Alice",
+      givenname: "Allison",
+      role: "user",
+      isDeleted: false
+    },
+    {
+      username: "Fred",
+      givenname: "Alfred",
+      role: "conf_admin",
+      isDeleted: true
+    }
+  ];
 
+  test("it renders with data", async function (assert) {
     this.set("users", users);
 
     await render(hbs`<Admin::User::Table @users={{this.users}} />`);
@@ -51,5 +57,33 @@ module("Integration | Component | admin/user/table", function (hooks) {
     assert.ok(text.includes("Alice"));
 
     assert.ok(!text.includes("Fred"));
+  });
+
+  test("sorting works", async function (assert) {
+    this.set("users", users);
+
+    await render(hbs`<Admin::User::Table @users={{this.users}} />`);
+    let text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
+    assert.ok(text.indexOf("Fred") == -1);
+
+    await click('span[id="sort-username"]');
+    text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
+    assert.ok(text.indexOf("Fred") == -1);
+
+    await click('span[id="sort-name"]');
+    text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") < text.indexOf("Bob"));
+    assert.ok(text.indexOf("Fred") == -1);
+
+    await click('span[id="sort-name"]');
+    text = this.element.textContent.trim();
+
+    assert.ok(text.indexOf("Alice") > text.indexOf("Bob"));
+    assert.ok(text.indexOf("Fred") == -1);
   });
 });


### PR DESCRIPTION
admin/user table can now be sorted by each attribute by clicking on the small arrow next to it in the table header. Attributes are initially sorted in ascending order, a second click sorts in descending order - except for the "last login at" attribute which is initially sorted in descending order to display most recent logins at the top. 