### PR TITLE
fix arrow direction in folder navigation

### DIFF
--- a/frontend/app/templates/components/folder/show.hbs
+++ b/frontend/app/templates/components/folder/show.hbs
@@ -29,9 +29,9 @@
     <div class="col-auto pl-0 justify-content-between d-flex align-items-center">
       <span role="button" name="folder-collapse" {{on "click" this.toggleExpanded }}>
         {{#if this.isExpanded}}
-          <img class="icon-big-button float-right" src="/assets/images/angle-left.svg" alt="<">
-        {{else}}
           <img class="icon-big-button float-right" src="/assets/images/angle-down.svg" alt="v">
+        {{else}}
+          <img class="icon-big-button float-right" src="/assets/images/angle-left.svg" alt="<">
         {{/if}}
       </span>
     </div>


### PR DESCRIPTION
Fixed the direction of the arrows. No tests were affected and there seems to be no other occurrence of this bug.