### PR TITLE
Respect line breaks in descriptions

### DIFF
--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -266,6 +266,7 @@ li a {
 
 .description {
   overflow: auto;
+  white-space: pre-line;
 }
 
 .folder-no-p {


### PR DESCRIPTION
We often use line breaks in password descriptions. With this change, they are visible in the show view.