### PR TITLE
include private field in serializer

### DIFF
--- a/app/serializers/team_list_serializer.rb
+++ b/app/serializers/team_list_serializer.rb
@@ -3,7 +3,7 @@
 class TeamListSerializer < ApplicationSerializer
   # To hide STI name in Frontend
   type Team.name.pluralize
-  attributes :id, :name, :type, :personal_team
+  attributes :id, :name, :type, :personal_team, :private
 
   has_many :folders, serializer: FolderMinimalSerializer
 

--- a/app/serializers/team_list_serializer.rb
+++ b/app/serializers/team_list_serializer.rb
@@ -3,7 +3,7 @@
 class TeamListSerializer < ApplicationSerializer
   # To hide STI name in Frontend
   type Team.name.pluralize
-  attributes :id, :name, :type, :personal_team, :private
+  attributes :id, :name, :type, :personal_team
 
   has_many :folders, serializer: FolderMinimalSerializer
 


### PR DESCRIPTION
Was gemacht wurde:

- Private field von Teams wird nun auch nach vorne gereicht
- Private teams werden nun mit "encrypted_small_white.svg" Icon dargestellt