### PR TITLE
delete forgotten script tag which references deleted file

### DIFF
--- a/public/frontend-index-development.html
+++ b/public/frontend-index-development.html
@@ -21,7 +21,6 @@
 
     <script src="http://localhost:4200/assets/vendor.js"></script>
     <script src="http://localhost:4200/assets/frontend.js"></script>
-    <script src="http://localhost:4200/assets/pzsh-bundle.js"></script>
 
     <div id="ember-bootstrap-wormhole"></div>
 <div id="ember-basic-dropdown-wormhole"></div>


### PR DESCRIPTION
Was gemacht wurde:

- Unnötiges "script"-Tag, welches beim Löschen des Referenzfiles vergessen wurde, wurde entfernt