### PR TITLE
Pin cdxgen version for now

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install cdxgen
         run: |
-          npm install -g @cyclonedx/cdxgen
+          npm install -g @cyclonedx/cdxgen@8.6.0
 
       - name: 'Generate SBOM for ruby dependencies'
         run: |


### PR DESCRIPTION
The cyclonedx-cli doesn't yet Support the 1.5 Spec
https://github.com/CycloneDX/cyclonedx-cli/issues/324

Which was added here
https://github.com/CycloneDX/cdxgen/commit/700cbd889fe80ca60a1f6a3b47f83fffe43fa117

Henceforth, the package is pinned until the cli has caught up.