### PR TITLE
Bug/757-fix-encryptable-search

### DIFF
--- a/app/serializers/folder_serializer.rb
+++ b/app/serializers/folder_serializer.rb
@@ -18,18 +18,8 @@
 #  https://github.com/puzzle/cryptopus.
 
 class FolderSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description, :unread_transferred_count
+  attributes :id, :name, :description
 
-  has_many :encryptables, serializer: EncryptableMinimalSerializer do
-    if object.personal_inbox?
-      object.encryptables.order('created_at DESC')
-    else
-      object.encryptables.order(:name)
-    end
-  end
-
-  def unread_transferred_count
-    object.personal_inbox? ? object.unread_count_transferred_encryptables : nil
-  end
+  has_many :encryptables, serializer: EncryptableMinimalSerializer
 
 end

--- a/app/serializers/folder_serializer.rb
+++ b/app/serializers/folder_serializer.rb
@@ -18,8 +18,11 @@
 #  https://github.com/puzzle/cryptopus.
 
 class FolderSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description
+  attributes :id, :name, :description, :unread_transferred_count
 
   has_many :encryptables, serializer: EncryptableMinimalSerializer
 
+  def unread_transferred_count
+    object.personal_inbox? ? object.unread_count_transferred_encryptables : nil
+  end
 end

--- a/spec/controllers/api/teams_controller_spec.rb
+++ b/spec/controllers/api/teams_controller_spec.rb
@@ -180,7 +180,10 @@ describe Api::TeamsController do
       expect(folder_relationships_length).to be(1)
     end
 
-    it 'returns encryptable files for team_id, in order from created_at' do
+    ## TODO: Activate test after order logic has been implemented again
+    # Has been ignored because order logic in serializer had to be removed to make search work
+    # Ticket: https://github.com/orgs/puzzle/projects/5/views/1?pane=issue&itemId=51495477
+    xit 'returns encryptable files for team_id, in order from created_at' do
       inbox_folder_receiver = alice.inbox_folder
       personal_team_alice = teams(:personal_team_alice)
 

--- a/spec/controllers/api/teams_controller_spec.rb
+++ b/spec/controllers/api/teams_controller_spec.rb
@@ -180,7 +180,7 @@ describe Api::TeamsController do
       expect(folder_relationships_length).to be(1)
     end
 
-    ## TODO: Re-enable after fixing encryptables ordering, see #760
+    ## TODO: Re-enable after fixing encryptables ordering, see https://github.com/puzzle/cryptopus/issues/760
     xit 'returns encryptable files for team_id, in order from created_at' do
       inbox_folder_receiver = alice.inbox_folder
       personal_team_alice = teams(:personal_team_alice)

--- a/spec/controllers/api/teams_controller_spec.rb
+++ b/spec/controllers/api/teams_controller_spec.rb
@@ -180,9 +180,7 @@ describe Api::TeamsController do
       expect(folder_relationships_length).to be(1)
     end
 
-    ## TODO: Activate test after order logic has been implemented again
-    # Has been ignored because order logic in serializer had to be removed to make search work
-    # Ticket: https://github.com/orgs/puzzle/projects/5/views/1?pane=issue&itemId=51495477
+    ## TODO: Re-enable after fixing encryptables ordering, see #760
     xit 'returns encryptable files for team_id, in order from created_at' do
       inbox_folder_receiver = alice.inbox_folder
       personal_team_alice = teams(:personal_team_alice)

--- a/spec/system/search_system_spec.rb
+++ b/spec/system/search_system_spec.rb
@@ -73,23 +73,22 @@ describe 'TeamModal', type: :system, js: true do
     Fabricate(:credential_all_attrs,
               folder: target_folder,
               team_password: team_password,
-              name: 'credentials3')
+              name: 'Rocket Access Codes')
     Fabricate(:credential_all_attrs,
               folder: target_folder,
               team_password: team_password,
-              name: 'credentials4')
+              name: 'Github Account')
 
-    encryptable1 = encryptables(:credentials2)
     expect(find('pzsh-banner input.search')['placeholder']).to eq('Type to search in all teams...')
-    find('pzsh-banner input.search').set encryptable1.name
+    find('pzsh-banner input.search').set 'Twitter'
 
     within 'div[role="main"]' do
       expect(page).to have_text(teams(:team2).name)
       expect(page).to have_text(folders(:folder2).name)
       expect(page).to have_text(encryptables(:credentials2).name)
       expect(page).to have_selector('.encryptable-row', count: 1)
-      expect(page).not_to have_text('credentials3')
-      expect(page).not_to have_text('credentials4')
+      expect(page).not_to have_text('Rocket Access Codes')
+      expect(page).not_to have_text('Github Account')
     end
   end
 

--- a/spec/system/search_system_spec.rb
+++ b/spec/system/search_system_spec.rb
@@ -61,6 +61,23 @@ describe 'TeamModal', type: :system, js: true do
     end
   end
 
+  it 'finds matching encryptable' do
+    login_as_user(:bob)
+    visit('/')
+
+    encryptable1 = encryptables(:credentials2)
+
+    expect(find('pzsh-banner input.search')['placeholder']).to eq('Type to search in all teams...')
+    find('pzsh-banner input.search').set encryptable1.name
+
+    within 'div[role="main"]' do
+      expect(page).to have_text(teams(:team2).name)
+      expect(page).to have_text(folders(:folder2).name)
+      expect(page).to have_text(encryptables(:credentials2).name)
+      expect(page).to have_selector('.encryptable-row', count: 1)
+    end
+  end
+
   it 'search starts after 2 chars' do
     login_as_user(:bob)
     visit('/')

--- a/spec/system/search_system_spec.rb
+++ b/spec/system/search_system_spec.rb
@@ -11,6 +11,8 @@ require 'spec_helper'
 describe 'TeamModal', type: :system, js: true do
   include SystemHelpers
 
+  let(:bob) { users(:bob) }
+
   it 'finds matching accounts' do
     login_as_user(:bob)
     visit('/')
@@ -65,8 +67,19 @@ describe 'TeamModal', type: :system, js: true do
     login_as_user(:bob)
     visit('/')
 
-    encryptable1 = encryptables(:credentials2)
+    private_key = decrypt_private_key(bob)
+    target_folder = folders(:folder2)
+    team_password = target_folder.team.decrypt_team_password(bob, private_key)
+    Fabricate(:credential_all_attrs,
+              folder: target_folder,
+              team_password: team_password,
+              name: 'credentials3')
+    Fabricate(:credential_all_attrs,
+              folder: target_folder,
+              team_password: team_password,
+              name: 'credentials4')
 
+    encryptable1 = encryptables(:credentials2)
     expect(find('pzsh-banner input.search')['placeholder']).to eq('Type to search in all teams...')
     find('pzsh-banner input.search').set encryptable1.name
 
@@ -75,6 +88,8 @@ describe 'TeamModal', type: :system, js: true do
       expect(page).to have_text(folders(:folder2).name)
       expect(page).to have_text(encryptables(:credentials2).name)
       expect(page).to have_selector('.encryptable-row', count: 1)
+      expect(page).not_to have_text('credentials3')
+      expect(page).not_to have_text('credentials4')
     end
   end
 


### PR DESCRIPTION
What was made:
- Search has been fixed (When searching for an encryptable it will return only the searched one)
- A e2e test has been added to verify the above described behaviour
- One Unit Test has been ignored because it requires ordering the data after it has been selected 
=> We will fix this in another Ticket: #760 